### PR TITLE
Adding other state actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Use this URL for the source of the module. See the usage examples below for more details.
 
 ```hcl
-github.com/pbs/terraform-aws-synthetics-module?ref=0.1.0
+github.com/pbs/terraform-aws-synthetics-module?ref=x.y.z
 ```
 
 ### Alternative Installation Methods
@@ -22,7 +22,7 @@ Integrate this module like so:
 
 ```hcl
 module "synthetics" {
-  source = "github.com/pbs/terraform-aws-synthetics-module?ref=0.1.0"
+  source = "github.com/pbs/terraform-aws-synthetics-module?ref=x.y.z"
 
   zip_file = "path/to/file.zip"
 
@@ -48,7 +48,7 @@ The recommended workaround for this is to use something external to Terraform (l
 
 If this repo is added as a subtree, then the version of the module should be close to the version shown here:
 
-`0.1.0`
+`x.y.z`
 
 Note, however that subtrees can be altered as desired within repositories.
 
@@ -98,7 +98,7 @@ Below is automatically generated documentation on this Terraform module using [t
 | <a name="input_organization"></a> [organization](#input\_organization) | Organization using this module. Used to prefix tags so that they are easily identified as being from your organization | `string` | n/a | yes |
 | <a name="input_product"></a> [product](#input\_product) | Tag used to group resources according to product | `string` | n/a | yes |
 | <a name="input_repo"></a> [repo](#input\_repo) | Tag used to point to the repo using this module | `string` | n/a | yes |
-| <a name="input_alarm_config"></a> [alarm\_config](#input\_alarm\_config) | Configurations for the alarm | <pre>object({<br>    comparison_operator = string<br>    period              = number<br>    evaluation_periods  = number<br>    metric_name         = string<br>    namespace           = string<br>    statistic           = string<br>    datapoints_to_alarm = number<br>    threshold           = string<br>    actions             = list(string)<br>    description         = optional(string)<br>  })</pre> | <pre>{<br>  "actions": [],<br>  "comparison_operator": "LessThanThreshold",<br>  "datapoints_to_alarm": 1,<br>  "description": null,<br>  "evaluation_periods": 1,<br>  "metric_name": "SuccessPercent",<br>  "namespace": "CloudWatchSynthetics",<br>  "period": 300,<br>  "statistic": "Sum",<br>  "threshold": "90"<br>}</pre> | no |
+| <a name="input_alarm_config"></a> [alarm\_config](#input\_alarm\_config) | Configurations for the alarm | <pre>object({<br>    comparison_operator       = string<br>    period                    = number<br>    evaluation_periods        = number<br>    metric_name               = string<br>    namespace                 = string<br>    statistic                 = string<br>    datapoints_to_alarm       = number<br>    threshold                 = string<br>    alarm_actions             = list(string)<br>    ok_actions                = list(string)<br>    insufficient_data_actions = list(string)<br>    description               = optional(string)<br>  })</pre> | <pre>{<br>  "alarm_actions": [],<br>  "comparison_operator": "LessThanThreshold",<br>  "datapoints_to_alarm": 1,<br>  "description": null,<br>  "evaluation_periods": 1,<br>  "insufficient_data_actions": [],<br>  "metric_name": "SuccessPercent",<br>  "namespace": "CloudWatchSynthetics",<br>  "ok_actions": [],<br>  "period": 300,<br>  "statistic": "Sum",<br>  "threshold": "90"<br>}</pre> | no |
 | <a name="input_artifact_config"></a> [artifact\_config](#input\_artifact\_config) | Configuration for canary artifacts, including the encryption-at-rest settings for artifacts that the canary uploads to Amazon S3. | <pre>object({<br>    s3_encryption = optional(object({<br>      encryption_mode = optional(string)<br>      kms_key_arn     = optional(string)<br>    }))<br>  })</pre> | `null` | no |
 | <a name="input_canary_script_s3_location"></a> [canary\_script\_s3\_location](#input\_canary\_script\_s3\_location) | Location in Amazon S3 where Synthetics stores the canary script for a canary. Conflicts with `zip_file`. | <pre>object({<br>    bucket  = optional(string)<br>    key     = optional(string)<br>    version = optional(string)<br>  })</pre> | `{}` | no |
 | <a name="input_delete_lambda"></a> [delete\_lambda](#input\_delete\_lambda) | Specifies whether to also delete the Lambda functions and layers used by this canary. | `bool` | `false` | no |

--- a/alarm.tf
+++ b/alarm.tf
@@ -1,15 +1,17 @@
 resource "aws_cloudwatch_metric_alarm" "alarm" {
-  alarm_name          = "canary-${local.name}"
-  comparison_operator = var.alarm_config.comparison_operator
-  period              = var.alarm_config.period
-  evaluation_periods  = var.alarm_config.evaluation_periods
-  metric_name         = var.alarm_config.metric_name
-  namespace           = var.alarm_config.namespace
-  statistic           = var.alarm_config.statistic
-  datapoints_to_alarm = var.alarm_config.datapoints_to_alarm
-  threshold           = var.alarm_config.threshold
-  alarm_actions       = var.alarm_config.actions
-  alarm_description   = var.alarm_config.description != null ? var.alarm_config.description : "Alarm for ${local.name} Canary"
+  alarm_name                = "canary-${local.name}"
+  comparison_operator       = var.alarm_config.comparison_operator
+  period                    = var.alarm_config.period
+  evaluation_periods        = var.alarm_config.evaluation_periods
+  metric_name               = var.alarm_config.metric_name
+  namespace                 = var.alarm_config.namespace
+  statistic                 = var.alarm_config.statistic
+  datapoints_to_alarm       = var.alarm_config.datapoints_to_alarm
+  threshold                 = var.alarm_config.threshold
+  alarm_actions             = var.alarm_config.alarm_actions
+  ok_actions                = var.alarm_config.ok_actions
+  insufficient_data_actions = var.alarm_config.insufficient_data_actions
+  alarm_description         = var.alarm_config.description != null ? var.alarm_config.description : "Alarm for ${local.name} Canary"
   dimensions = {
     CanaryName = local.name
   }

--- a/optional-alarm.tf
+++ b/optional-alarm.tf
@@ -1,27 +1,31 @@
 variable "alarm_config" {
   description = "Configurations for the alarm"
   type = object({
-    comparison_operator = string
-    period              = number
-    evaluation_periods  = number
-    metric_name         = string
-    namespace           = string
-    statistic           = string
-    datapoints_to_alarm = number
-    threshold           = string
-    actions             = list(string)
-    description         = optional(string)
+    comparison_operator       = string
+    period                    = number
+    evaluation_periods        = number
+    metric_name               = string
+    namespace                 = string
+    statistic                 = string
+    datapoints_to_alarm       = number
+    threshold                 = string
+    alarm_actions             = list(string)
+    ok_actions                = list(string)
+    insufficient_data_actions = list(string)
+    description               = optional(string)
   })
   default = {
-    comparison_operator = "LessThanThreshold"
-    period              = 300
-    evaluation_periods  = 1
-    metric_name         = "SuccessPercent"
-    namespace           = "CloudWatchSynthetics"
-    statistic           = "Sum"
-    datapoints_to_alarm = 1
-    threshold           = "90"
-    actions             = []
-    description         = null
+    comparison_operator       = "LessThanThreshold"
+    period                    = 300
+    evaluation_periods        = 1
+    metric_name               = "SuccessPercent"
+    namespace                 = "CloudWatchSynthetics"
+    statistic                 = "Sum"
+    datapoints_to_alarm       = 1
+    threshold                 = "90"
+    alarm_actions             = []
+    ok_actions                = []
+    insufficient_data_actions = []
+    description               = null
   }
 }


### PR DESCRIPTION
Adding support for `alarm_actions`, `ok_actions` and `insufficient_data_actions` instead of only supporting `alarm_actions`.

This is a breaking change as it results in the `alarm_config` type changing.