### PR TITLE
Add options to provide policy, as well as extend or use default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea
+.vscode
 .terraform
 .DS_Store
 target

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.24.0"
   constraints = ">= 4.5.0"
   hashes = [
+    "h1:5kF6+4jUPI73O/uDvm/8/NiKRhiaOqMTqdo5l8uAygo=",
     "h1:tAteY6hnPFlxGx88cjNXQT3x5Of6lz0EUaZTn3wsjUA=",
     "zh:164b4ac71c9fc6b991021dd6e829591b0c1a0ebfb5831da0a7eb4f10f92c76a7",
     "zh:22e85772a1767498796f160b54a156db8173c4e238469dad8328a65093e033e1",

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Use this URL for the source of the module. See the usage examples below for more details.
 
 ```hcl
-github.com/pbs/terraform-aws-synthetics-module?ref=2.0.14
+github.com/pbs/terraform-aws-synthetics-module?ref=x.y.z
 ```
 
 ### Alternative Installation Methods
@@ -22,7 +22,7 @@ Integrate this module like so:
 
 ```hcl
 module "synthetics" {
-  source = "github.com/pbs/terraform-aws-synthetics-module?ref=2.0.14"
+  source = "github.com/pbs/terraform-aws-synthetics-module?ref=x.y.z"
 
   zip_file = "path/to/file.zip"
 
@@ -48,7 +48,7 @@ The recommended workaround for this is to use something external to Terraform (l
 
 If this repo is added as a subtree, then the version of the module should be close to the version shown here:
 
-`2.0.14`
+`x.y.z`
 
 Note, however that subtrees can be altered as desired within repositories.
 
@@ -101,6 +101,7 @@ Below is automatically generated documentation on this Terraform module using [t
 | <a name="input_alarm_config"></a> [alarm\_config](#input\_alarm\_config) | Configurations for the alarm | <pre>object({<br>    comparison_operator       = optional(string, "LessThanThreshold")<br>    period                    = optional(number, 300)<br>    evaluation_periods        = optional(number, 1)<br>    metric_name               = optional(string, "SuccessPercent")<br>    namespace                 = optional(string, "CloudWatchSynthetics")<br>    statistic                 = optional(string, "Sum")<br>    datapoints_to_alarm       = optional(number, 1)<br>    threshold                 = optional(string, "90")<br>    alarm_actions             = optional(list(string), [])<br>    ok_actions                = optional(list(string), [])<br>    insufficient_data_actions = optional(list(string), [])<br>    treat_missing_data        = optional(string, "missing")<br>    description               = optional(string)<br>  })</pre> | <pre>{<br>  "alarm_actions": [],<br>  "comparison_operator": "LessThanThreshold",<br>  "datapoints_to_alarm": 1,<br>  "description": null,<br>  "evaluation_periods": 1,<br>  "insufficient_data_actions": [],<br>  "metric_name": "SuccessPercent",<br>  "namespace": "CloudWatchSynthetics",<br>  "ok_actions": [],<br>  "period": 300,<br>  "statistic": "Sum",<br>  "threshold": "90",<br>  "treat_missing_data": "missing"<br>}</pre> | no |
 | <a name="input_artifact_config"></a> [artifact\_config](#input\_artifact\_config) | Configuration for canary artifacts, including the encryption-at-rest settings for artifacts that the canary uploads to Amazon S3. | <pre>object({<br>    s3_encryption = optional(object({<br>      encryption_mode = optional(string)<br>      kms_key_arn     = optional(string)<br>    }))<br>  })</pre> | `null` | no |
 | <a name="input_canary_script_s3_location"></a> [canary\_script\_s3\_location](#input\_canary\_script\_s3\_location) | Location in Amazon S3 where Synthetics stores the canary script for a canary. Conflicts with `zip_file`. | <pre>object({<br>    bucket  = optional(string)<br>    key     = optional(string)<br>    version = optional(string)<br>  })</pre> | `{}` | no |
+| <a name="input_cumulative_policy"></a> [cumulative\_policy](#input\_cumulative\_policy) | A boolean indicating whether to add the user-provided policy to the default policy. | `bool` | `false` | no |
 | <a name="input_delete_lambda"></a> [delete\_lambda](#input\_delete\_lambda) | Specifies whether to also delete the Lambda functions and layers used by this canary. | `bool` | `false` | no |
 | <a name="input_execution_role_arn"></a> [execution\_role\_arn](#input\_execution\_role\_arn) | ARN of the IAM role to be used to run the canary. | `string` | `null` | no |
 | <a name="input_execution_role_name"></a> [execution\_role\_name](#input\_execution\_role\_name) | Name of the execution role created by this module, if one is created. If null, will default to name. | `string` | `null` | no |
@@ -108,6 +109,7 @@ Below is automatically generated documentation on this Terraform module using [t
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | Specifies whether to force destroy the bucket containing the canary artifacts. This is required when the bucket contains objects. The default value is `false`. | `bool` | `false` | no |
 | <a name="input_handler"></a> [handler](#input\_handler) | Entry point to use for the source code when running the canary. This value must end with the string `.handler`. | `string` | `"canary.handler"` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the synthetics module. If null, will default to product. | `string` | `null` | no |
+| <a name="input_role_policy"></a> [role\_policy](#input\_role\_policy) | The IAM role policy to provide the canary. | `string` | `null` | no |
 | <a name="input_run_config"></a> [run\_config](#input\_run\_config) | Configuration block for individual canary runs. | <pre>object({<br>    timeout_in_seconds    = optional(number)<br>    memory_in_mb          = optional(number)<br>    active_tracing        = optional(bool)<br>    environment_variables = optional(map(string))<br>  })</pre> | `null` | no |
 | <a name="input_runtime_version"></a> [runtime\_version](#input\_runtime\_version) | Specifies the runtime version to use for the canary. For a list of valid runtime versions, see Canary Runtime Versions. | `string` | `"syn-nodejs-puppeteer-6.0"` | no |
 | <a name="input_schedule"></a> [schedule](#input\_schedule) | Schedule for how often the canary is to run and when these test runs are to stop. | <pre>object({<br>    expression          = string<br>    duration_in_seconds = optional(number)<br>  })</pre> | <pre>{<br>  "expression": "rate(5 minutes)"<br>}</pre> | no |

--- a/examples/basic/.terraform.lock.hcl
+++ b/examples/basic/.terraform.lock.hcl
@@ -4,6 +4,7 @@
 provider "registry.terraform.io/hashicorp/archive" {
   version = "2.4.0"
   hashes = [
+    "h1:EtN1lnoHoov3rASpgGmh6zZ/W6aRCTgKC7iMwvFY1yc=",
     "h1:cJokkjeH1jfpG4QEHdRx0t2j8rr52H33A7C/oX73Ok4=",
     "zh:18e408596dd53048f7fc8229098d0e3ad940b92036a24287eff63e2caec72594",
     "zh:392d4216ecd1a1fd933d23f4486b642a8480f934c13e2cae3c13b6b6a7e34a7b",
@@ -25,6 +26,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = ">= 4.5.0"
   hashes = [
     "h1:H/nY2teFoN9LU+Xtc1dx7TGS6w2HrARs0Q7cFb6vbus=",
+    "h1:W9SNPJwklBwrSNCdY8MHET9yFJlM5vVSxb7szD5pzFk=",
     "zh:12059dc2b639797b9facb6397ac6aec563891634be8e5aadf3a457590c1147d4",
     "zh:1b3515d70b6998359d0a6d3b3c287940ab2e5c59cd02f95c7d9dab7df76e86b6",
     "zh:423a1d3afdb6b625f2e3b06770ef4324740d400ff1a0d6d566c87d3f841d74fc",

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -33,4 +33,7 @@ module "synthetics" {
   environment  = var.environment
   product      = var.product
   repo         = var.repo
+  role_policy = jsonencode(
+    { "Statement" : [{ "Effect" : "Allow", "Action" : ["ssm:GetParameters"], "Resource" : "*" }] }
+  )
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,7 +1,7 @@
 locals {
   name = var.name != null ? var.name : var.product
 
-  # Snapshot Bucket
+  # Snapshot Bucket and CloudWatch permissions
   default_policy = jsonencode({
     "Version" : "2012-10-17",
     "Statement" : [
@@ -58,6 +58,8 @@ locals {
     ]
   })
 
+  # Merge the default policy with the user provided policy if cumulative_policy is true, otherwise overwrite it with the user provided policy
+  # If the user provided policy is null, use the default policy
   aggregate_policy = var.role_policy != null ? (var.cumulative_policy ? merge(local.default_policy, var.role_policy) : var.role_policy) : local.default_policy
 
   execution_role_arn = var.execution_role_arn != null ? var.execution_role_arn : module.role[0].arn

--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,65 @@
 locals {
   name = var.name != null ? var.name : var.product
 
+  # Snapshot Bucket
+  default_policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "s3:PutObject",
+          "s3:GetObject"
+        ],
+        "Resource" : [
+          "${module.s3.arn}/*"
+        ]
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "s3:GetBucketLocation"
+        ],
+        "Resource" : [
+          module.s3.arn
+        ]
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:CreateLogGroup"
+        ],
+        "Resource" : [
+          "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/cwsyn-${local.name}*"
+        ]
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "s3:ListAllMyBuckets",
+          "xray:PutTraceSegments"
+        ],
+        "Resource" : [
+          "*"
+        ]
+      },
+      {
+        "Effect" : "Allow",
+        "Resource" : "*",
+        "Action" : "cloudwatch:PutMetricData",
+        "Condition" : {
+          "StringEquals" : {
+            "cloudwatch:namespace" : "CloudWatchSynthetics"
+          }
+        }
+      }
+    ]
+  })
+
+  aggregate_policy = var.role_policy != null ? (var.cumulative_policy ? merge(local.default_policy, var.role_policy) : var.role_policy) : local.default_policy
+
   execution_role_arn = var.execution_role_arn != null ? var.execution_role_arn : module.role[0].arn
 
   artifact_s3_location = "s3://${module.s3.name}/"

--- a/optional.tf
+++ b/optional.tf
@@ -64,6 +64,22 @@ variable "failure_retention_period" {
   }
 }
 
+variable "cumulative_policy" {
+  description = "A boolean indicating whether to add the user-provided policy to the default policy."
+  type        = bool
+  default     = false
+}
+
+variable "role_policy" {
+  description = "The IAM role policy to provide the canary."
+  type        = string
+  default     = null
+  validation {
+    condition     = var.role_policy != null ? can(jsondecode(var.role_policy)) : true
+    error_message = "Failed to decode role_policy json"
+  }
+}
+
 variable "run_config" {
   description = "Configuration block for individual canary runs."
   type = object({

--- a/security.tf
+++ b/security.tf
@@ -5,61 +5,7 @@ module "role" {
 
   name = local.execution_role_name
 
-  policy_json = jsonencode({
-    "Version" : "2012-10-17",
-    "Statement" : [
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "s3:PutObject",
-          "s3:GetObject"
-        ],
-        "Resource" : [
-          "${module.s3.arn}/*"
-        ]
-      },
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "s3:GetBucketLocation"
-        ],
-        "Resource" : [
-          module.s3.arn
-        ]
-      },
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "logs:CreateLogStream",
-          "logs:PutLogEvents",
-          "logs:CreateLogGroup"
-        ],
-        "Resource" : [
-          "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/cwsyn-${local.name}*"
-        ]
-      },
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "s3:ListAllMyBuckets",
-          "xray:PutTraceSegments"
-        ],
-        "Resource" : [
-          "*"
-        ]
-      },
-      {
-        "Effect" : "Allow",
-        "Resource" : "*",
-        "Action" : "cloudwatch:PutMetricData",
-        "Condition" : {
-          "StringEquals" : {
-            "cloudwatch:namespace" : "CloudWatchSynthetics"
-          }
-        }
-      }
-    ]
-  })
+  policy_json = local.aggregate_policy
 
   # Tagging Parameters
   organization = var.organization


### PR DESCRIPTION
Give the user a means of augmenting the permissions afforded the canary. Permissions can result from either the default policy, the default policy in addition to a user-supplied policy, or only the user-supplied permissions (overwrite the default policy).