### PR TITLE
Allowing module consumers to provide an optional policy_json to override the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Use this URL for the source of the module. See the usage examples below for more details.
 
 ```hcl
-github.com/pbs/terraform-aws-synthetics-module?ref=2.0.22
+github.com/pbs/terraform-aws-synthetics-module?ref=x.y.z
 ```
 
 ### Alternative Installation Methods
@@ -22,7 +22,7 @@ Integrate this module like so:
 
 ```hcl
 module "synthetics" {
-  source = "github.com/pbs/terraform-aws-synthetics-module?ref=2.0.22"
+  source = "github.com/pbs/terraform-aws-synthetics-module?ref=x.y.z"
 
   zip_file = "path/to/file.zip"
 
@@ -48,7 +48,7 @@ The recommended workaround for this is to use something external to Terraform (l
 
 If this repo is added as a subtree, then the version of the module should be close to the version shown here:
 
-`2.0.22`
+`x.y.z`
 
 Note, however that subtrees can be altered as desired within repositories.
 
@@ -108,6 +108,7 @@ Below is automatically generated documentation on this Terraform module using [t
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | Specifies whether to force destroy the bucket containing the canary artifacts. This is required when the bucket contains objects. The default value is `false`. | `bool` | `false` | no |
 | <a name="input_handler"></a> [handler](#input\_handler) | Entry point to use for the source code when running the canary. This value must end with the string `.handler`. | `string` | `"canary.handler"` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the synthetics module. If null, will default to product. | `string` | `null` | no |
+| <a name="input_policy_json"></a> [policy\_json](#input\_policy\_json) | Policy JSON. If null, default policy granting S3, logging, and XRay will be attached | `string` | `null` | no |
 | <a name="input_run_config"></a> [run\_config](#input\_run\_config) | Configuration block for individual canary runs. | <pre>object({<br>    timeout_in_seconds    = optional(number)<br>    memory_in_mb          = optional(number)<br>    active_tracing        = optional(bool)<br>    environment_variables = optional(map(string))<br>  })</pre> | `null` | no |
 | <a name="input_runtime_version"></a> [runtime\_version](#input\_runtime\_version) | Specifies the runtime version to use for the canary. For a list of valid runtime versions, see Canary Runtime Versions. | `string` | `"syn-nodejs-puppeteer-7.0"` | no |
 | <a name="input_schedule"></a> [schedule](#input\_schedule) | Schedule for how often the canary is to run and when these test runs are to stop. | <pre>object({<br>    expression          = string<br>    duration_in_seconds = optional(number)<br>  })</pre> | <pre>{<br>  "expression": "rate(5 minutes)"<br>}</pre> | no |

--- a/optional.tf
+++ b/optional.tf
@@ -136,3 +136,9 @@ variable "execution_role_name" {
   type        = string
   default     = null
 }
+
+variable "policy_json" {
+  description = "Policy JSON. If null, default policy granting S3, logging, and XRay will be attached"
+  type        = string
+  default     = null
+}

--- a/security.tf
+++ b/security.tf
@@ -5,7 +5,7 @@ module "role" {
 
   name = local.execution_role_name
 
-  policy_json = jsonencode({
+  policy_json = var.policy_json != null ? var.policy_json : jsonencode({
     "Version" : "2012-10-17",
     "Statement" : [
       {


### PR DESCRIPTION
I'll need this for a canary I'm working on that needs to fetch API keys from SSM.